### PR TITLE
Potential DEREF_OF_NULL

### DIFF
--- a/agent/mibgroup/agent/extend.c
+++ b/agent/mibgroup/agent/extend.c
@@ -358,6 +358,9 @@ extend_load_cache(netsnmp_cache *cache, void *magic)
         if (out_len > 0 && out_buf[out_len - 1] == '\n')
             out_buf[--out_len] = '\0';	/* Strip trailing newline */
         extension->output   = strdup( out_buf );
+	if (extension->output == NULL) {
+	    return -1;
+	}
         extension->out_len  = out_len;
         /*
          * Now we need to pick the output apart into separate lines.


### PR DESCRIPTION
Potential DEREF_OF_NULL if strdup() fails to allocate memory, it will return NULL. The patch added a check for the return value.

Found by Linux Verification Center (linuxtesting.org) with SVACE.
Reporter: Dmitrii Fedin ([d.fedin@fobos-nt.ru](mailto:d.fedin@fobos-nt.ru)).

